### PR TITLE
fix: exit with code 1 when job timed out

### DIFF
--- a/turbine-deploy.sh
+++ b/turbine-deploy.sh
@@ -134,3 +134,4 @@ for i in $(seq 1 100); do
 done
 
 echo "Time out while waiting for job to end"
+exit 1


### PR DESCRIPTION
When the job is timed out, I assume the deployment is not successful and the action status should be failed instead of success.