### PR TITLE
Add `exclude_env_types` parameter to `image_post_build` job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   environment:
     description: 'the environment where to deploy this component version'
     required: false
+  exclude_env_types:
+    description: 'the environment types excluded by deploy'
+    required: false
+    default: 'prep,prod'
 
 runs:
   using: 'composite'
@@ -27,3 +31,4 @@ runs:
         TURBINE_VERSION: ${{ inputs.version }}
         TURBINE_COMPONENT: ${{ inputs.component }}
         TURBINE_ENVIRONMENT: ${{ inputs.environment }}
+        TURBINE_EXCLUDE_ENV_TYPES: ${{ inputs.exclude_env_types }}

--- a/turbine-deploy.sh
+++ b/turbine-deploy.sh
@@ -59,7 +59,8 @@ then
 	  "type": "image_post_build",
 	  "parameters": {
 	    "component": "'$COMPONENT_NAME'",
-	    "version": "'$VERSION_TO_DEPLOY'"
+	    "version": "'$VERSION_TO_DEPLOY'",
+	    "exclude_env_types": "'$TURBINE_EXCLUDE_ENV_TYPES'"
 	  },
 	  "state": "PENDING"
 	}' $TURBINE_JOBS_URL)


### PR DESCRIPTION
ℹ️ I defined default Turbine parameter value in `action.yml` because: 
* GitHub Action inputs don't support "null" value
* empty value has different beheviors than "undefined"